### PR TITLE
3 build the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/24 12:52:25 by lfarias-          #+#    #+#              #
-#    Updated: 2023/07/25 15:07:51 by lfarias-         ###   ########.fr        #
+#    Updated: 2023/07/26 13:31:51 by lfarias-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -18,10 +18,12 @@ CXXFLAGS	= -Wall -Werror -Wextra -std=c++98 -g
 
 TEST_BUILD 	= tests/build
 
-APP = $(addprefix srcs/, \
-	main.cpp)
+INPUT = $(addprefix input/, \
+	InputHandler.cpp)
 
-SRC			= $(APP)
+SRC			= $(addprefix src/, \
+	$(INPUT) 					 \
+	main.cpp)
 
 OBJ			= $(SRC:.cpp=.o)
 

--- a/include/input/InputHandler.hpp
+++ b/include/input/InputHandler.hpp
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   InputHandler.hpp                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/07/26 12:03:58 by lfarias-          #+#    #+#             */
+/*   Updated: 2023/07/26 12:40:30 by lfarias-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef INPUTHANDLER_HPP
+# define INPUTHANDLER_HPP
+
+class InputHandler {
+ private:
+  InputHandler(void);
+  InputHandler(const InputHandler& f);
+  InputHandler& operator=(const InputHandler& t);
+  ~InputHandler(void);
+
+ public:
+  static bool check_args(int argc, const char **argv);
+};
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,0 @@
-#include <iostream>
-
-int main() {
-  std::cout << "Hello webserv world" << std::endl;
-  return 0;
-}

--- a/src/input/InputHandler.cpp
+++ b/src/input/InputHandler.cpp
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   InputHandler.cpp                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/07/26 12:05:52 by lfarias-          #+#    #+#             */
+/*   Updated: 2023/07/26 13:30:18 by lfarias-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/input/InputHandler.hpp"
+
+#include <cstring>
+
+bool  InputHandler::check_args(int argc, const char **argv) {
+  if ((argc - 1) == 1) {
+    size_t filenameLen = strlen(argv[1]);
+    if (filenameLen > 5 && strncmp(&argv[1][filenameLen - 5], ".conf", 5) == 0)
+      return (true);
+    else
+      return (false);
+  }
+  return ((argc - 1) == 0);
+}

--- a/src/input/InputHandler.cpp
+++ b/src/input/InputHandler.cpp
@@ -6,16 +6,17 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/26 12:05:52 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/07/26 13:30:18 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/07/26 14:19:40 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../include/input/InputHandler.hpp"
 
 #include <cstring>
+#include <iostream>
 
 bool  InputHandler::check_args(int argc, const char **argv) {
-  if ((argc - 1) == 1) {
+  if ((argc - 1) == 1 && argv[1] != NULL) {
     size_t filenameLen = strlen(argv[1]);
     if (filenameLen > 5 && strncmp(&argv[1][filenameLen - 5], ".conf", 5) == 0)
       return (true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,25 +6,17 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/24 13:03:50 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/07/25 15:44:56 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/07/26 13:30:49 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <iostream>
-#include <string>
-#include <cstring>
+#include "../include/input/InputHandler.hpp"
 
-bool  check_args(int argc, const char **argv) {
-  if ((argc - 1) == 1) {
-    size_t filenameLen = strlen(argv[1]);
-    if (filenameLen > 5 && strncmp(&argv[1][filenameLen - 5], ".conf", 5) == 0)
-      return (true);
-    else
-      return (false);
+int main(int argc, char **argv) {
+  if (!InputHandler::check_args(argc, const_cast<const char **>(argv))) {
+    std::cout << "[USAGE]:  ./webserv <configuration file>.conf" << std::endl;
+    return(1);
   }
-  return ((argc - 1) == 0);
+  std::cout << "Hello webserv world" << std::endl;
 }
-
-// int main(int argc, char **argv) {
-//   std::cout << "Hello webserv world" << std::endl;
-// }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,16 +22,17 @@ set(CMAKE_CXX_STANDARD 14)
 
 enable_testing()
 
-# set(Headers
-#	../headers/webserv.h
-# )
+set(Includes
+    ../include/input/InputHandler.hpp
+)
 
 set(Sources
-	../srcs/main.cpp
+	../src/main.cpp
+    ../src/input/InputHandler.cpp
 )
 
 # add_library(${This} ${Sources} ${Libft} ${Headers})
-add_library(${This} ${Sources})
+add_library(${This} ${Sources} ${Includes})
 
 # this will add all the subdirectories with unit tests
 add_subdirectory(InputTests)

--- a/tests/InputTests/InputTests.cpp
+++ b/tests/InputTests/InputTests.cpp
@@ -1,22 +1,21 @@
 #include <gtest/gtest.h>
-
-bool  check_args(int argc, const char **argv);
+#include "../../include/input/InputHandler.hpp"
 
 TEST(InputTests, BasicTests)
 {
   {
     const char *argv[2] = {"webserv", "myserver.conf"};
-    EXPECT_TRUE(check_args(2, argv));
+    EXPECT_TRUE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", "a.conf"};
-    EXPECT_TRUE(check_args(2, argv));
+    EXPECT_TRUE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", ".conf"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 }
 
@@ -24,31 +23,31 @@ TEST(InputTests, ExtensionTests)
 {
   {
     const char *argv[2] = {"webserv", "myserver.con"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", "myserver.config"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", "myserverconfig"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", "myserver.cnf"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", "config"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 
   {
     const char *argv[2] = {"webserv", ".cnf"};
-    EXPECT_FALSE(check_args(2, argv));
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 }

--- a/tests/InputTests/InputTests.cpp
+++ b/tests/InputTests/InputTests.cpp
@@ -56,3 +56,15 @@ TEST(InputTests, ExtensionTests)
     EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
 }
+
+TEST(InputTests, ArgcTests)
+{
+    const char *argv[2] = {"webserv", "default.conf"};
+
+    EXPECT_FALSE(InputHandler::check_args(42, argv));
+    EXPECT_FALSE(InputHandler::check_args(3, argv));
+    EXPECT_FALSE(InputHandler::check_args(0, argv));
+    EXPECT_FALSE(InputHandler::check_args(-2, argv));
+    EXPECT_FALSE(InputHandler::check_args(-42, argv));
+    EXPECT_FALSE(InputHandler::check_args(-3, argv));
+}

--- a/tests/InputTests/InputTests.cpp
+++ b/tests/InputTests/InputTests.cpp
@@ -17,6 +17,11 @@ TEST(InputTests, BasicTests)
     const char *argv[2] = {"webserv", ".conf"};
     EXPECT_FALSE(InputHandler::check_args(2, argv));
   }
+
+  {
+    const char *argv[2] = {NULL, NULL};
+    EXPECT_FALSE(InputHandler::check_args(2, argv));
+  }
 }
 
 TEST(InputTests, ExtensionTests)


### PR DESCRIPTION
The check args is now part of the static class `InputHandler`, the main goal is to have this class handle all the logic that validates the configuration file
The actual reading and parsing of the information can be delegated to other classes in the future, but the interface would be on `InputHandler`. this is subject to change, but that's the main motivation for the class, right now.

The header files can now be found in the `include` folder and they mimic the internal hierarchy of `src`

I added one more battery of tests just for the argc component of `InputHandler::check_args(int argc, char** argv)`
I also fixed one edge case where the function would break in case of a NULL value creeping into it.

