### PR TITLE
39 implement time out

### DIFF
--- a/include/socket/Controller.hpp
+++ b/include/socket/Controller.hpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 20:48:07 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/09 14:39:57 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/11 21:27:56 by dvargas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@
 #include <vector>
 #include <map>
 
+#define TIMEOUT 600
+
 class Controller {
  public:
   Controller(const InputHandler &input);
@@ -35,6 +37,7 @@ class Controller {
   std::vector<int>              connections;
   std::vector<TCPServerSocket*> socketList;
   std::map<int, char *>         bufferList;  // connectionFD, buffer
+  std::map<int, time_t>          timeoutList;
   int                           epollfd;
   struct epoll_event            events[MAX_EVENTS];
 
@@ -51,5 +54,7 @@ class Controller {
   //signal handler
   static void endServer();
   static void signalHandler(int signal);
+int findConnectionSocket(int socketFD);
+void checkTimeOut();
 };
 #endif

--- a/include/socket/Controller.hpp
+++ b/include/socket/Controller.hpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 20:48:07 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/11 21:27:56 by dvargas          ###   ########.fr       */
+/*   Updated: 2023/08/11 21:32:52 by dvargas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@
 #include <vector>
 #include <map>
 
-#define TIMEOUT 600
+#define TIMEOUT 60
 
 class Controller {
  public:

--- a/include/socket/TcpServerSocket.hpp
+++ b/include/socket/TcpServerSocket.hpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/26 15:29:55 by dvargas           #+#    #+#             */
-/*   Updated: 2023/08/08 13:53:14 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/11 08:48:03 by dvargas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,6 @@ class TCPServerSocket {
   ~TCPServerSocket(void);
 
   int   bindAndListen(void);
-  // static void handleSIGINT(int); IMPLEMENT ON CONTROLLER!
   int   acceptConnection(void);
   int   receiveData(int connection, char* buffer, int bufferSize);
   void  sendData(int connection, const char* data, int dataSize);

--- a/src/socket/Controller.cpp
+++ b/src/socket/Controller.cpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 20:51:31 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/11 21:28:59 by dvargas          ###   ########.fr       */
+/*   Updated: 2023/08/11 21:30:40 by dvargas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -175,7 +175,6 @@ void  Controller::closeConnection(int currentFd) {
       break;
     }
   }
-  // timeoutList.erase(currentFd);
 }
 
 bool Controller::isNewConnection(int currentFD) {

--- a/src/socket/Controller.cpp
+++ b/src/socket/Controller.cpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 20:51:31 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/09 14:40:18 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/11 21:28:59 by dvargas          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,6 +89,7 @@ void Controller::handleConnections(void) {
       if (isNewConnection(currentFd)) {
         std::cout << "new conection" << std::endl;
         addNewConnection(currentFd);  // if new connection found, add it.
+        // std::cout << "ALOUOUUOUOUOUOU" << serverList[currentFd]->getPort() << std::endl;
       } else if ((currentEvent & EPOLLRDHUP) == EPOLLRDHUP) {
         std::cout << "Connection with FD -> " << currentFd;
         std::cout << " is closed by client" << std::endl;
@@ -104,7 +105,32 @@ void Controller::handleConnections(void) {
         }
       }
     }
+    checkTimeOut();
   }
+}
+
+void Controller::checkTimeOut() {
+  time_t currentTime = time(NULL);
+  std::vector<int> clientsToRemove;
+  for (std::map<int, time_t>::iterator it = timeoutList.begin(); it != timeoutList.end(); ) {
+    if (currentTime - it->second > TIMEOUT) {
+      std::cout << "removing client: " << it->first << " due to timeout" << std::endl;
+      clientsToRemove.push_back(it->first);
+    }
+    ++it;
+  }
+ for (std::vector<int>::iterator it = clientsToRemove.begin(); it != clientsToRemove.end(); ++it) {
+    closeConnection(*it);
+    timeoutList.erase(*it);
+  }
+}
+
+int Controller::findConnectionSocket (int socketFD) {
+    for (size_t i = 0; i < socketList.size(); i++) {
+    if (socketFD == socketList[i]->getFD())
+      return (i);
+  }
+  return (-1);
 }
 
 void Controller::addNewConnection(int socketFD) {
@@ -124,9 +150,10 @@ void Controller::addNewConnection(int socketFD) {
 
     if (it == bufferList.end())  // no existing buffer for current fd
       bufferList[newConnection] = new char[1024];
-
     *bufferList[newConnection] = '\0';
 
+    time_t currentTime = time(NULL);
+    timeoutList[newConnection] = currentTime;
     if (epoll_ctl(epollfd, EPOLL_CTL_ADD, newConnection, events) == -1) {
       std::cerr << "Failed to add new connection to epoll. errno: " << errno
                 << std::endl;
@@ -148,6 +175,7 @@ void  Controller::closeConnection(int currentFd) {
       break;
     }
   }
+  // timeoutList.erase(currentFd);
 }
 
 bool Controller::isNewConnection(int currentFD) {


### PR DESCRIPTION
created a map to eventfd(int) and an time_t 
created a function to check timeoutfrom events in pool "checkTimeOut()" 
after "for" we check if any connections should be timeouted and the function is responsable to remove and erase the client from list of connections.
Right now the timeout is set manually in the define, in the future it can be an arg on config file for each server.