### PR TITLE
33 handle accepted http methods

### DIFF
--- a/include/http/HttpRequest.hpp
+++ b/include/http/HttpRequest.hpp
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 00:34:36 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/12 10:04:53 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 15:50:04 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define HTTPREQUEST_HPP
 
 #include <string>
+#include <vector>
 
 class HttpRequest {
  public:
@@ -35,17 +36,19 @@ class HttpRequest {
   void          setModifiedTimestampCheck(std::string timestamp);
   std::string   getUnmodifiedSinceTimestamp(void);
   void          setUnmodifiedSinceTimestamp(std::string timestamp);
-
+  std::vector<std::string>   getAllowedMethods(void);
+  void          setAllowedMethods(std::vector<std::string> allowedList);
 
  private:
-  std::string   protocolName;
-  int           protocolMainVersion;
-  int           protocolSubVersion;
-  std::string   host;
-  std::string   resource;
-  std::string   method;
-  std::string   modifiedTimestampCheck;
-  std::string   unmodifiedSinceTimestamp;
+  std::string               protocolName;
+  int                       protocolMainVersion;
+  int                       protocolSubVersion;
+  std::string               host;
+  std::string               resource;
+  std::string               method;
+  std::string               modifiedTimestampCheck;
+  std::string               unmodifiedSinceTimestamp;
+  std::vector<std::string>  allowedMethodList;
 
   HttpRequest(const HttpRequest& f);
   HttpRequest& operator=(const HttpRequest& t);

--- a/include/http/Server.hpp
+++ b/include/http/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 17:23:14 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/10 07:25:24 by dvargas          ###   ########.fr       */
+/*   Updated: 2023/08/12 15:30:34 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,9 +46,10 @@ class Server {
   TCPServerSocket               *socket;
   std::map<int, std::string>    error_pages;
   std::vector<s_locationConfig> locations;
-  std::string      createLocation(char *buffer);
 
   Server(const Server& f);
   Server& operator=(const Server& t);
+
+  std::string      createLocation(char *buffer);
 };
 #endif

--- a/src/http/HttpRequest.cpp
+++ b/src/http/HttpRequest.cpp
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 00:36:19 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/12 10:07:10 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 15:51:21 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,13 +69,21 @@ void HttpRequest::setModifiedTimestampCheck(std::string timestamp) {
 }
 
 std::string HttpRequest::getModifiedTimestampCheck(void) {
-  return (modifiedTimestampCheck);
+  return (this->modifiedTimestampCheck);
 }
 
 std::string HttpRequest::getUnmodifiedSinceTimestamp(void) {
-  return (unmodifiedSinceTimestamp);
+  return (this->unmodifiedSinceTimestamp);
 }
 
 void HttpRequest::setUnmodifiedSinceTimestamp(std::string unmodifiedTimestamp) {
   unmodifiedSinceTimestamp = unmodifiedTimestamp;
+}
+
+std::vector<std::string> HttpRequest::getAllowedMethods(void) {
+  return (this->allowedMethodList);
+}
+
+void HttpRequest::setAllowedMethods(std::vector<std::string> allowedList) {
+  allowedMethodList = allowedList;
 }

--- a/src/http/HttpResponseComposer.cpp
+++ b/src/http/HttpResponseComposer.cpp
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/05 21:21:24 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/10 21:42:25 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 18:15:31 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ void HttpResponseComposer::buildErrorResponse(HttpResponse *response, \
                                        std::map<int, std::string> error_pages, \
                                        int protoMainVersion, \
                                        int protoSubVersion) {
+  // shim
   response->setProtocol("HTTP", protoMainVersion, protoSubVersion);
   response->setStatusCode(error_code);
 

--- a/src/http/MimeType.cpp
+++ b/src/http/MimeType.cpp
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/29 12:12:09 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/07/29 20:29:14 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 17:59:29 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,13 +18,17 @@ std::map<std::string, std::string> MimeType::types;
 
 std::string MimeType::identify(const std::string &str) {
   init_table();
-  int pos = str.rfind('.');
-  std::string extension = str.substr(pos, std::string::npos);
-  std::string type = types[extension];
-  if (type == "")
-    return "application/octet-stream";
-  else
-    return type;
+  size_t pos = str.rfind('.');
+  std::string type;
+
+  if (pos != std::string::npos) {
+    std::string extension = str.substr(pos, std::string::npos);
+    type = types[extension];
+  } else {
+    type = "application/octet-stream";
+  }
+
+  return type;
 }
 
 void MimeType::init_table(void) {

--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 17:22:33 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/12 19:21:06 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 19:57:50 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -126,9 +126,42 @@ void Server::get(HttpRequest *request, HttpResponse *response) {
 }
 
 void Server::head(HttpRequest *request, HttpResponse *response) {
-  this->get(request, response);
-  std::vector<char> empty;
-  response->setMsgBody(empty);
+  int protoMain = request->getProtocolMainVersion();
+  int protoSub = request->getProtocolSubVersion();
+  response->setProtocol("HTTP", protoMain, protoSub);
+
+  int opStatus = 0;
+  if (access(request->getResource().c_str(), F_OK) == -1) {
+    opStatus = 404;
+  } else if (access(request->getResource().c_str(), R_OK) == -1) {
+    opStatus = 403;
+  }
+
+  if (opStatus != 0) {
+    HttpResponseComposer::buildErrorResponse(response, opStatus, error_pages, \
+                                             request->getProtocolMainVersion(), \
+                                             request->getProtocolSubVersion());
+    return;
+  }
+
+  std::string modifiedTimestmap = request->getModifiedTimestampCheck();
+
+  if (!HttpTime::isModifiedSince(modifiedTimestmap, request->getResource())) {
+    response->setStatusCode(304);
+    return;
+  }
+
+  response->setLastModifiedTime(HttpTime::getLastModifiedTime(request->getResource()));
+  struct stat fileInfo;
+  off_t fileSize;
+
+  if (stat(request->getResource().c_str(), &fileInfo) == 0) {
+    fileSize = fileInfo.st_size;
+  }
+
+  response->setStatusCode(200);
+  response->setContentType(MimeType::identify(request->getResource()));
+  response->setContentLength(fileSize);
 }
 
 void Server::del(HttpRequest *request, HttpResponse *response) {

--- a/src/http/Server.cpp
+++ b/src/http/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 17:22:33 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/12 19:07:03 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 19:21:06 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -135,21 +135,18 @@ void Server::del(HttpRequest *request, HttpResponse *response) {
   std::ifstream inputFile;
   int protoMain = request->getProtocolMainVersion();
   int protoSub = request->getProtocolSubVersion();
+  int opStatus = 0;
 
   if (access(request->getResource().c_str(), F_OK) == -1) {
-    HttpResponseComposer::buildErrorResponse(response, 404, error_pages, \
-                                             protoMain, protoSub);
-    return;
+    opStatus = 404;
+  } else if (access(request->getResource().c_str(), R_OK | W_OK) == -1) {
+    opStatus = 405;
+  } else if (remove(request->getResource().c_str()) != 0) {
+    opStatus = 500;
   }
 
-  if (access(request->getResource().c_str(), R_OK | W_OK) == -1) {
-    HttpResponseComposer::buildErrorResponse(response, 405, error_pages, \
-                                             protoMain, protoSub);
-    return;
-  }
-
-  if (remove(request->getResource().c_str()) != 0) {
-    HttpResponseComposer::buildErrorResponse(response, 500, error_pages, \
+  if (opStatus != 0) {
+    HttpResponseComposer::buildErrorResponse(response, opStatus, error_pages, \
                                              protoMain, protoSub);
     return;
   }

--- a/src/input/InputHandler.cpp
+++ b/src/input/InputHandler.cpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/26 12:05:52 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/10 09:12:51 by dvargas          ###   ########.fr       */
+/*   Updated: 2023/08/12 20:15:04 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,7 +69,7 @@ void InputHandler::addToString(std::ifstream &fileStream, \
 }
 
 bool InputHandler::isAMethod(std::string word) {
-  if (word == "GET" || word == "POST" || word == "DELETE")
+  if (word == "GET" || word == "POST" || word == "DELETE" || word == "HEAD")
     return true;
   return false;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/26 08:40:49 by dvargas           #+#    #+#             */
-/*   Updated: 2023/08/08 18:29:10 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 17:01:25 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,16 +22,15 @@ int main(int argc, char **argv) {
     return(1);
   }
 
-  try {
+  //try {
     InputHandler input(argv[1]);
     input.printServers();
     Controller controller(input);
     controller.init();
-  }
-  catch(const std::exception& e) {
+ /* catch(const std::exception& e) {
     std::cerr << e.what() << '\n';
     return (1);
-  }
+  }*/
 
   return 0;
 }

--- a/src/utils/FileReader.cpp
+++ b/src/utils/FileReader.cpp
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/10 20:32:28 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/10 21:15:11 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/08/12 18:37:09 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,11 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+bool isRegularFile(const std::string &filename);
+
 int FileReader::getContent(const std::string &fileName, std::vector<char> *resourceData) {
   std::ifstream inputFile;
+
 
   if (access(fileName.c_str(), F_OK) == -1) {
     return 404;
@@ -27,6 +30,9 @@ int FileReader::getContent(const std::string &fileName, std::vector<char> *resou
   if (access(fileName.c_str(), R_OK) == -1) {
     return 403;
   }
+
+  if (!isRegularFile(fileName.c_str()))
+    return (404);
 
   inputFile.open(fileName.c_str(), std::ios::binary);
 
@@ -43,4 +49,9 @@ int FileReader::getContent(const std::string &fileName, std::vector<char> *resou
 
   inputFile.close();
   return (0);
+}
+
+bool isRegularFile(const std::string &filename) {
+    struct stat fileInfo;
+    return (stat(filename.c_str(), &fileInfo) == 0) && S_ISREG(fileInfo.st_mode);
 }


### PR DESCRIPTION
Web server now successfully handles Allowed/Accepted methods

On a blocked request the server will respond with a `405 - Method not allowed`

To test this I used curl with the -I flag, this will send just a HEAD request.

I also did some refactoring on the head and delete methods.