### PR TITLE
Refactor: change Controller to use map for its serverList and socketList

### DIFF
--- a/include/socket/Controller.hpp
+++ b/include/socket/Controller.hpp
@@ -6,7 +6,7 @@
 /*   By: dvargas <dvargas@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 20:48:07 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/08/11 21:32:52 by dvargas          ###   ########.fr       */
+/*   Updated: 2023/08/15 22:54:18 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,13 +33,13 @@ class Controller {
   void  handleConnections(void);
 
  private:
-  std::vector<Server*>          serverList;
-  std::vector<int>              connections;
-  std::vector<TCPServerSocket*> socketList;
-  std::map<int, char *>         bufferList;  // connectionFD, buffer
-  std::map<int, time_t>          timeoutList;
-  int                           epollfd;
-  struct epoll_event            events[MAX_EVENTS];
+  std::vector<int>                connections;
+  std::map<int, Server*>          serverList;
+  std::map<int, TCPServerSocket*> socketList;
+  std::map<int, char *>           bufferList;  // connectionFD, buffer
+  std::map<int, time_t>           timeoutList;
+  int                             epollfd;
+  struct epoll_event              events[MAX_EVENTS];
 
   Controller(const Controller& f);
   Controller& operator=(const Controller& t);
@@ -54,7 +54,8 @@ class Controller {
   //signal handler
   static void endServer();
   static void signalHandler(int signal);
-int findConnectionSocket(int socketFD);
-void checkTimeOut();
+
+  int findConnectionSocket(int socketFD);
+  void checkTimeOut();
 };
 #endif


### PR DESCRIPTION
the server picking and socket picking logic inside Controller::sendDataToClient were reworked to use maps instead of vectors due to the O(log n) nature of accessing their elements, the previous implementation used vectors and if we wanted to find a specific server or socket we would need to iterate through the vector, checking for equality of the server/socket port.

with this change I hope the code can be more performative when put to stress during siege.